### PR TITLE
Adds two new parameters to plugin-bigfoot

### DIFF
--- a/layouts/partials/bigfoot.html
+++ b/layouts/partials/bigfoot.html
@@ -1,6 +1,15 @@
 <script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js"></script>
 <script type="text/javascript" src="{{ "assets/bigfoot/dist/bigfoot.min.js" | relURL }}"></script>
-<link rel="stylesheet" type="text/css" href="{{ "assets/bigfoot/dist/bigfoot-number.css" | relURL }}" />
+<link rel="stylesheet" type="text/css" href="
+                      {{ if params.use_numbers }}
+                        {{ "assets/bigfoot/dist/bigfoot-number.css" | relURL }}
+                      {{ else }}
+                        {{ "assets/bigfoot/dist/bigfoot-base.css" | relURL}} 
+                        {{ end }}" />
 <script type="text/javascript">
-    $.bigfoot();
+  $.bigfoot(
+    {
+      numberResetSelector: {{ params.post_separator }}
+    }
+  );
 </script>

--- a/plugin.json
+++ b/plugin.json
@@ -1,8 +1,19 @@
 {
-  "version": "1.0.0",
+  "version": "1.0.1",
   "title": "Bigfoot",
   "description": "Adds Bigfoot.js to your Micro.blog theme.",
   "includes": [
     "bigfoot.html"
+  ]
+  "fields": [
+    {
+      "field": "params.post_separator",
+      "label": "What CSS selector separates out posts on your index pages (to force numbers to restart correctly)?"
+      "placeholder": "article.h-entry"
+    }
+    {
+      "field": "params.use_numbers",
+      "label: "Use numbers?" 
+      "type": "boolean"
   ]
 }

--- a/plugin.json
+++ b/plugin.json
@@ -8,12 +8,12 @@
   "fields": [
     {
       "field": "params.post_separator",
-      "label": "What CSS selector separates out posts on your index pages (to force numbers to restart correctly)?"
+      "label": "What CSS selector separates out posts on your index pages (to force numbers to restart correctly)?",
       "placeholder": "article.h-entry"
     }
     {
       "field": "params.use_numbers",
-      "label: "Use numbers?" 
+      "label": "Use numbers?", 
       "type": "boolean"
   ]
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.1",
+  "version": "1.1.0",
   "title": "Bigfoot",
   "description": "Adds Bigfoot.js to your Micro.blog theme.",
   "includes": [


### PR DESCRIPTION
Adds two parameters -- `use_numbers` and `post_separator`. The first will change between using the numbers css or base css for formatting footnotes (whether you get ... or 1). The second will set the CSS selector the will "reset" the numbers. Therefore, on an index page with multiple posts, the footnote numbers don't continue across posts but reset at each new post.